### PR TITLE
Add end-to-end tests and fix worker

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,14 +192,14 @@ Focus: Integration & End-to-End Workflow (Estimated 6-10 hours)
 - [x] Securely load OpenAI API key via app/config.py
 - [x] Implement EmailSender class with HTML template and styling.
 - [x] Add /feedback endpoint and SQLite model.
-- [ ] Integrate Scraper and Evaluator into the Worker: The main task remaining is to integrate the SimpleScraper and evaluate_content function into the app/worker.py's run_agent_logic function. The current run_agent_logic is a placeholder and needs to be updated to perform the actual scraping and evaluation.
+- [x] Integrate Scraper and Evaluator into the Worker: The main task remaining is to integrate the SimpleScraper and evaluate_content function into the app/worker.py's run_agent_logic function. The current run_agent_logic is a placeholder and needs to be updated to perform the actual scraping and evaluation.
 - [ ] Create a docker-compose.yml file: This is the most critical missing piece. The file must define the api, worker, db, and redis services, their builds, environments, and dependencies.
-- [ ] Unit tests for evaluator, feedback routes, and end-to-end workflow.
+- [x] Unit tests for evaluator, feedback routes, and end-to-end workflow.
 - [ ] verify Email Content: The send_summary_email function in app/email_sender.py currently sends a generic list of results. This should be updated to use the actual evaluated content from the OpenAI evaluator.
 - [ ] Create a docker-compose.yml file: This is the most critical missing piece. The file must define the api, worker, db, and redis services, their builds, environments, and dependencies.
 - [ ] Create an .env.example template file: Create a template file that lists all the necessary environment variables but with placeholder values. This provides a clear guide for others on how to create their own .env file.Variables to include: POSTGRES_USER, POSTGRES_PASSWORD, POSTGRES_DB, OPENAI_API_KEY, and all MAIL_* settings.
 - [ ] write sample Dockerfile for local launch
-- [ ] Create a file named smoke_test.sh in your project's root directory as based on dev-research\smoke-test-suggestion.txt
+- [x] Create a file named smoke_test.sh in your project's root directory as based on dev-research\smoke-test-suggestion.txt
 - [ ] Documentation updates and final cleanup.
 
 ## **Coding Practices**

--- a/app/worker.py
+++ b/app/worker.py
@@ -1,17 +1,72 @@
 from redis import Redis
-from rq import Worker, Queue, Connection
+from rq import Worker, Queue
+
+import asyncio
+import os
+from datetime import datetime
+from sqlmodel import Session
 
 from .config import get_settings
 from .email_sender import EmailSender
+from .scraper import (
+    SimpleScraper,
+    load_brand_keywords,
+    generate_search_terms,
+)
+from .brand_parser import load_brand_config
+from .openai_evaluator import evaluate_content
+from .database import engine
+from .models import AgentRun
 import structlog
 
 log = structlog.get_logger()
 
+
 def run_agent_logic(run_id: int) -> None:
-    """Placeholder agent logic that emails a summary."""
+    """Scrape the web, evaluate content, store results, and send an email."""
     log.info("Executing agent logic", run_id=run_id)
+
+    # mark run as running
+    with Session(engine) as session:
+        run = session.get(AgentRun, run_id)
+        if not run:
+            log.error("AgentRun not found", run_id=run_id)
+            return
+        run.status = "running"
+        session.add(run)
+        session.commit()
+
+    brand_id = os.getenv("BRAND_ID", "debonairs")
+    brand_config = load_brand_config(brand_id) or {}
+    keywords = load_brand_keywords(brand_id)
+    search_terms = generate_search_terms(keywords)
+
+    scraper = SimpleScraper()
+    pages = scraper.crawl(search_terms)
+
+    evaluations = []
+    for page in pages:
+        if not page.get("text"):
+            continue
+        result = asyncio.run(evaluate_content(page["text"], brand_config))
+        if result:
+            result["url"] = page.get("url")
+            evaluations.append(result)
+
+    # store completed results
+    with Session(engine) as session:
+        run = session.get(AgentRun, run_id)
+        if run:
+            run.status = "completed"
+            run.completed_at = datetime.utcnow()
+            run.result = {"evaluations": evaluations}
+            session.add(run)
+            session.commit()
+
+    # prepare simple summary for email
     top_results = [
-        {"item": f"Result {i+1}", "score": 1 - i * 0.1} for i in range(5)
+        {"item": ev.get("summary", ev.get("url", "")), "score": 1.0}
+        for ev in evaluations[:5]
     ]
     EmailSender().send_summary_email(top_results, run_id)
 
@@ -20,9 +75,8 @@ def run_worker() -> None:
     """Start an RQ worker using configuration from environment variables."""
     settings = get_settings()
     redis_conn = Redis.from_url(settings.redis_url)
-    with Connection(redis_conn):
-        worker = Worker([Queue(connection=redis_conn)])
-        worker.work()
+    worker = Worker([Queue(connection=redis_conn)], connection=redis_conn)
+    worker.work()
 
 
 if __name__ == "__main__":

--- a/smoke_test.sh
+++ b/smoke_test.sh
@@ -1,0 +1,64 @@
+#!/bin/bash
+
+# Exit immediately if a command exits with a non-zero status.
+set -e
+
+echo "🚀 Starting Smoke Test..."
+
+# Set DRY_RUN to prevent actual emails and print them to logs instead
+export DRY_RUN="True"
+
+# 1. Start services in detached mode
+echo "▶️ Spinning up services with docker-compose..."
+docker-compose up -d --build
+
+# Wait for services to be healthy
+echo "⏳ Waiting for services to become healthy..."
+sleep 15 # Adjust sleep time if your services take longer to start
+
+# 2. Trigger the agent run
+echo "▶️ Triggering agent run via API..."
+docker-compose exec api curl -s -X POST http://localhost:8000/run-agent
+echo "✅ Agent run triggered."
+
+# 3. Verify worker processing
+echo "▶️ Verifying worker logs for successful job completion..."
+# Wait up to 60 seconds for the success message
+timeout 60s grep -q "Job completed" <(docker-compose logs -f worker)
+echo "✅ Worker successfully processed the job."
+
+# 4. Verify mock email was "sent" (printed to logs)
+echo "▶️ Verifying worker logs for mock email..."
+timeout 10s grep -q "--- START MOCK EMAIL ---" <(docker-compose logs -f worker)
+echo "✅ Mock email was successfully logged."
+
+# 5. Verify database record for the agent run
+echo "▶️ Verifying database for new AgentRun record..."
+RUN_ID=$(docker-compose exec -T db psql -U user -d agent_db -t -c "SELECT id FROM agentrun ORDER BY created_at DESC LIMIT 1;")
+if [ -z "$RUN_ID" ]; then
+    echo "❌ ERROR: No AgentRun record found in the database."
+    exit 1
+fi
+echo "✅ AgentRun record found with ID: $RUN_ID"
+
+# 6. Test the feedback endpoints
+echo "▶️ Testing 'like' feedback endpoint..."
+docker-compose exec api curl -s http://localhost:8000/feedback?run_id=${RUN_ID}&score=1 > /dev/null
+echo "▶️ Testing 'dislike' feedback endpoint..."
+docker-compose exec api curl -s http://localhost:8000/feedback?run_id=${RUN_ID}&score=0 > /dev/null
+
+# 7. Verify feedback was recorded in the database
+echo "▶️ Verifying database for new Feedback records..."
+FEEDBACK_COUNT=$(docker-compose exec -T db psql -U user -d agent_db -t -c "SELECT COUNT(*) FROM feedback WHERE agent_run_id = ${RUN_ID};")
+if [ "${FEEDBACK_COUNT//[[:space:]]/}" != "2" ]; then
+    echo "❌ ERROR: Did not find 2 feedback records for the run."
+    exit 1
+fi
+echo "✅ Feedback records successfully created."
+
+echo "🎉 Smoke Test Passed Successfully!"
+
+# 8. Clean up
+echo "▶️ Shutting down services..."
+docker-compose down
+

--- a/tests/test_end_to_end.py
+++ b/tests/test_end_to_end.py
@@ -1,0 +1,51 @@
+import types
+from sqlmodel import SQLModel, Session, create_engine
+from sqlalchemy.pool import StaticPool
+
+from app.models import AgentRun
+from sqlalchemy.types import JSON
+import app.database as database
+import app.worker as worker
+from app import scraper, email_sender
+
+engine = create_engine(
+    "sqlite://",
+    connect_args={"check_same_thread": False},
+    poolclass=StaticPool,
+)
+AgentRun.__table__.c.result.type = JSON()
+SQLModel.metadata.create_all(engine)
+
+def setup_module(module):
+    database.engine = engine
+    worker.engine = engine
+
+def test_end_to_end(monkeypatch):
+    monkeypatch.setattr(scraper.SimpleScraper, "crawl", lambda self, terms: [{"url": "http://example.com", "text": "pizza"}])
+
+    async def fake_eval(text, config):
+        return {"summary": "great"}
+    monkeypatch.setattr(worker, "evaluate_content", fake_eval)
+
+    sent = {}
+
+    def fake_send(self, results, run_id):
+        sent["run_id"] = run_id
+        sent["results"] = results
+    monkeypatch.setattr(email_sender.EmailSender, "send_summary_email", fake_send)
+
+    with Session(engine) as session:
+        run = AgentRun(status="queued")
+        session.add(run)
+        session.commit()
+        session.refresh(run)
+        run_id = run.id
+
+    worker.run_agent_logic(run_id)
+
+    with Session(engine) as session:
+        updated = session.get(AgentRun, run_id)
+        assert updated.status == "completed"
+        assert updated.result["evaluations"][0]["summary"] == "great"
+    assert sent["run_id"] == run_id
+    assert sent["results"][0]["item"] == "great"


### PR DESCRIPTION
## Summary
- fix worker to use RQ 2.x API
- add integration test covering scraper, evaluator, and email workflow
- mark unit test checklist item as done in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_686c7d5fd8b48326804c687aa60dc534