### PR TITLE
Add docker-compose configuration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,9 @@
-DATABASE_URL=sqlite:///./development.db
+POSTGRES_USER=user
+POSTGRES_PASSWORD=password
+POSTGRES_DB=agent_db
+DATABASE_URL=postgresql+psycopg2://user:password@db:5432/agent_db
 LOG_LEVEL=INFO
-REDIS_URL=redis://localhost:6379/0
+REDIS_URL=redis://redis:6379/0
 AGENT_RUN_INTERVAL_MINUTES=10
 SMTP_SERVER=smtp.example.com
 SMTP_PORT=587

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,12 @@
+FROM python:3.10-slim
+
+WORKDIR /app
+
+COPY . /app
+
+RUN pip install --no-cache-dir \
+    fastapi uvicorn sqlmodel psycopg2-binary \
+    apscheduler httpx python-dotenv structlog \
+    redis rq requests beautifulsoup4 openai pyyaml
+
+CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,61 @@
+version: '3.9'
+
+services:
+  api:
+    build: .
+    command: uvicorn app.main:app --host 0.0.0.0 --port 8000
+    volumes:
+      - .:/app
+    environment:
+      DATABASE_URL: postgresql+psycopg2://${POSTGRES_USER}:${POSTGRES_PASSWORD}@db:5432/${POSTGRES_DB}
+      REDIS_URL: redis://redis:6379/0
+      LOG_LEVEL: ${LOG_LEVEL:-INFO}
+      AGENT_RUN_INTERVAL_MINUTES: ${AGENT_RUN_INTERVAL_MINUTES:-10}
+      OPENAI_API_KEY: ${OPENAI_API_KEY}
+      SMTP_SERVER: ${SMTP_SERVER}
+      SMTP_PORT: ${SMTP_PORT:-587}
+      SMTP_USERNAME: ${SMTP_USERNAME}
+      SMTP_PASSWORD: ${SMTP_PASSWORD}
+      SENDER_EMAIL: ${SENDER_EMAIL}
+      RECEIVER_EMAIL: ${RECEIVER_EMAIL}
+    depends_on:
+      - db
+      - redis
+
+  worker:
+    build: .
+    command: python -m app.worker
+    volumes:
+      - .:/app
+    environment:
+      DATABASE_URL: postgresql+psycopg2://${POSTGRES_USER}:${POSTGRES_PASSWORD}@db:5432/${POSTGRES_DB}
+      REDIS_URL: redis://redis:6379/0
+      LOG_LEVEL: ${LOG_LEVEL:-INFO}
+      OPENAI_API_KEY: ${OPENAI_API_KEY}
+      SMTP_SERVER: ${SMTP_SERVER}
+      SMTP_PORT: ${SMTP_PORT:-587}
+      SMTP_USERNAME: ${SMTP_USERNAME}
+      SMTP_PASSWORD: ${SMTP_PASSWORD}
+      SENDER_EMAIL: ${SENDER_EMAIL}
+      RECEIVER_EMAIL: ${RECEIVER_EMAIL}
+    depends_on:
+      - db
+      - redis
+
+  db:
+    image: postgres:15
+    environment:
+      POSTGRES_USER: ${POSTGRES_USER:-user}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-password}
+      POSTGRES_DB: ${POSTGRES_DB:-agent_db}
+    volumes:
+      - pgdata:/var/lib/postgresql/data
+
+  redis:
+    image: redis:7
+    volumes:
+      - redisdata:/data
+
+volumes:
+  pgdata:
+  redisdata:


### PR DESCRIPTION
## Summary
- provide a base Dockerfile with dependencies
- add docker-compose.yml describing api, worker, db and redis services
- expand `.env.example` with database variables

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_686c817857188326a7e9f4701a5fe20f