### PR TITLE
Refactor run_agent_logic for structured searches

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,9 +176,9 @@ Goal: To evolve the agent from a simple brand monitor into a dual-purpose market
 
 To-Do List:
 
-1. Refactor Core Worker Logic (app/worker.py)  
-- [ ] Modify the run\_agent\_logic function to process a structured JSON request that separates brand\_health\_queries from market\_intelligence\_queries.  
-- [ ] Implement a loop or sequential calls within the function to execute scraping and evaluation for both Brand Health and Market Intelligence tasks independently.  
+1. Refactor Core Worker Logic (app/worker.py)
+- [x] Modify the run\_agent\_logic function to process a structured JSON request that separates brand\_health\_queries from market\_intelligence\_queries.
+- [x] Implement a loop or sequential calls within the function to execute scraping and evaluation for both Brand Health and Market Intelligence tasks independently.
 2. Enhance the AI Evaluator (evaluate\_content)  
 - [ ] Update the evaluate\_content function to accept a task\_type parameter (e.g., "brand\_health" or "market\_intelligence").  
 - [ ] Add conditional logic to tailor the AI's analysis.  

--- a/app/worker.py
+++ b/app/worker.py
@@ -3,6 +3,8 @@ from rq import Worker, Queue
 
 import asyncio
 import os
+import json
+import logging
 from datetime import datetime
 from sqlmodel import Session
 
@@ -19,11 +21,38 @@ from .database import engine
 from .models import AgentRun
 import structlog
 
+# Configure logging for better visibility
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s - %(levelname)s - %(message)s",
+)
+
 log = structlog.get_logger()
 
 
-def run_agent_logic(run_id: int) -> None:
-    """Scrape the web, evaluate content, store results, and send an email."""
+def load_search_config(config_path: str = "search_config.json") -> dict | None:
+    """Load search configuration from a JSON file."""
+    try:
+        with open(config_path, "r", encoding="utf-8") as f:
+            return json.load(f)
+    except FileNotFoundError:
+        logging.error(
+            "Configuration file not found at %s. Please create it.", config_path
+        )
+    except json.JSONDecodeError:
+        logging.error(
+            "Error decoding JSON from %s. Please check its format.", config_path
+        )
+    return None
+
+
+def run_agent_logic(run_id: int, search_request: dict | None = None) -> None:
+    """Scrape the web, evaluate content, store results, and send an email.
+
+    If ``search_request`` is provided, it should contain ``brand_health_queries``
+    and ``market_intelligence_queries`` lists which will be used instead of the
+    default keyword-generated search terms.
+    """
     log.info("Executing agent logic", run_id=run_id)
 
     # mark run as running
@@ -39,19 +68,38 @@ def run_agent_logic(run_id: int) -> None:
     brand_id = os.getenv("BRAND_ID", "debonairs")
     brand_config = load_brand_config(brand_id) or {}
     keywords = load_brand_keywords(brand_id)
-    search_terms = generate_search_terms(keywords)
 
     scraper = SimpleScraper()
-    pages = scraper.crawl(search_terms)
 
-    evaluations = []
-    for page in pages:
-        if not page.get("text"):
-            continue
-        result = asyncio.run(evaluate_content(page["text"], brand_config))
-        if result:
-            result["url"] = page.get("url")
-            evaluations.append(result)
+    evaluations: list[dict] = []
+
+    def crawl_and_evaluate(queries: list[str]) -> None:
+        pages = scraper.crawl(queries)
+        for page in pages:
+            if not page.get("text"):
+                continue
+            result = asyncio.run(evaluate_content(page["text"], brand_config))
+            if result:
+                result["url"] = page.get("url")
+                evaluations.append(result)
+
+    if search_request:
+        brand_queries = search_request.get("brand_health_queries") or []
+        if brand_queries:
+            log.info("Starting Brand Health analysis", queries=brand_queries)
+            crawl_and_evaluate(brand_queries)
+
+        market_queries = search_request.get("market_intelligence_queries") or []
+        if market_queries:
+            log.info("Starting Market Intelligence analysis", queries=market_queries)
+            crawl_and_evaluate(market_queries)
+
+        if not brand_queries and not market_queries:
+            search_terms = generate_search_terms(keywords)
+            crawl_and_evaluate(search_terms)
+    else:
+        search_terms = generate_search_terms(keywords)
+        crawl_and_evaluate(search_terms)
 
     # store completed results
     with Session(engine) as session:


### PR DESCRIPTION
## Summary
- support structured JSON search requests in `run_agent_logic`
- add helper `load_search_config` and basic logging
- mark worker refactor tasks done in README

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_686c84154e608326accaba4387fc56ac