### PR TITLE
Improve summary email formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,9 +187,9 @@ To-Do List:
 3. Create a Search Configuration Template
 - [x] Create a new template file named search\_config.json.example in the project's root directory.
 - [x] Populate it with a clear example structure, demonstrating how to define both brand\_health\_queries and market\_intelligence\_queries.
-4. Improve Email Summaries (app/email\_sender.py)  
-- [ ] Update the send\_summary\_email function to accept the consolidated results from both tasks.  
-- [ ] Re-format the email body to present the findings under two distinct, clear headings: Brand Health Report and Market Intelligence Briefing.  
+4. Improve Email Summaries (app/email\_sender.py)
+- [x] Update the send\_summary\_email function to accept the consolidated results from both tasks.
+- [x] Re-format the email body to present the findings under two distinct, clear headings: Brand Health Report and Market Intelligence Briefing.
 5. Update Project Documentation  
 - [ ] Revise the main project description to reflect its enhanced capabilities as a market intelligence tool.
 

--- a/tests/test_email_sender.py
+++ b/tests/test_email_sender.py
@@ -40,9 +40,17 @@ def test_send_summary_email(monkeypatch):
         receiver_email="receiver@example.com",
     )
 
-    sender.send_summary_email([{"item": "Pizza", "score": 0.9}], run_id=1)
+    summary = {
+        "brand_health": [{"item": "Pizza", "score": 0.9}],
+        "market_intelligence": [{"item": "Burgers", "score": 0.8}],
+    }
+
+    sender.send_summary_email(summary, run_id=1)
 
     assert dummy.started
     assert dummy.logged_in == ("user", "pass")
     assert dummy.sent
     assert isinstance(dummy.sent_msg, MIMEMultipart)
+    body = dummy.sent_msg.as_string()
+    assert "Brand Health Report" in body
+    assert "Market Intelligence Briefing" in body

--- a/tests/test_end_to_end.py
+++ b/tests/test_end_to_end.py
@@ -46,6 +46,6 @@ def test_end_to_end(monkeypatch):
     with Session(engine) as session:
         updated = session.get(AgentRun, run_id)
         assert updated.status == "completed"
-        assert updated.result["evaluations"][0]["summary"] == "great"
+        assert updated.result["brand_health"][0]["summary"] == "great"
     assert sent["run_id"] == run_id
-    assert sent["results"][0]["item"] == "great"
+    assert sent["results"]["brand_health"][0]["item"] == "great"


### PR DESCRIPTION
## Summary
- accept distinct brand & market results in `send_summary_email`
- update email body with "Brand Health Report" and "Market Intelligence Briefing" headings
- track separate evaluation lists in `run_agent_logic`
- adapt tests for the new summary structure
- mark README tasks as completed

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_686c8a0105bc8326a0328b204fb72b56