### PR TITLE
Implement intelligent error handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,11 +211,11 @@ This epic covers all work required to ensure the data received from the OpenAI A
 * All fields are correctly typed and include descriptions.
 
 **TODOs:**
-* \[ \] **Create `AnalysisResult` Schema:** In `app/models.py`, define a new Pydantic `BaseModel` named `AnalysisResult`.  
-* \[ \] **Define Nested `SentimentAnalysis` Model:** Inside `app/models.py`, create a nested `SentimentAnalysis` model with fields for `overall_sentiment` (using `Literal`) and `score` (`float`).  
-* \[ \] **Define Nested `Entity` Model:** Inside `app/models.py`, create a nested `Entity` model with fields for `name` (`str`) and `type` (`str`).  
-* \[ \] **Assemble Final Schema:** The `AnalysisResult` model should include fields for `summary` (`str`), `sentiment` (`SentimentAnalysis`), and `entities` (`List[Entity]`).  
-* \[ \] **Add Docstrings:** Ensure all models and fields have clear, descriptive docstrings as recommended in the research.
+* [x] **Create `AnalysisResult` Schema:** In `app/models.py`, define a new Pydantic `BaseModel` named `AnalysisResult`.
+* [x] **Define Nested `SentimentAnalysis` Model:** Inside `app/models.py`, create a nested `SentimentAnalysis` model with fields for `overall_sentiment` (using `Literal`) and `score` (`float`).
+* [x] **Define Nested `Entity` Model:** Inside `app/models.py`, create a nested `Entity` model with fields for `name` (`str`) and `type` (`str`).
+* [x] **Assemble Final Schema:** The `AnalysisResult` model should include fields for `summary` (`str`), `sentiment` (`SentimentAnalysis`), and `entities` (`List[Entity]`).
+* [x] **Add Docstrings:** Ensure all models and fields have clear, descriptive docstrings as recommended in the research.
 
 ### **User Story 2: Enforce the Data Contract (Estimated Time: 1.5 hours)**
 
@@ -229,14 +229,14 @@ This epic covers all work required to ensure the data received from the OpenAI A
 
 **TODOs:**
 
-* \[ \] **Add Dependency:** Add `instructor` to the project's dependencies (e.g., in a `requirements.txt` file).  
-* \[ \] **Patch OpenAI Client:** In `app/openai_evaluator.py`, import `instructor` and refactor the client initialization to use `instructor.from_openai(OpenAI())`.  
-* \[ \] **Refactor `evaluate_content`:**  
+* [x] **Add Dependency:** Add `instructor` to the project's dependencies (e.g., in a `requirements.txt` file).
+* [x] **Patch OpenAI Client:** In `app/openai_evaluator.py`, import `instructor` and refactor the client initialization to use `instructor.from_openai(OpenAI())`.
+* [x] **Refactor `evaluate_content`:**
   * Remove the `try...except json.JSONDecodeError` block.  
   * Remove the `response_format={"type": "json_object"}` parameter, as `instructor` handles this.  
   * Add the `response_model=AnalysisResult` parameter to the `client.chat.completions.create` call.  
-  * Update the function's return type hint to `-> AnalysisResult`.  
-* \[ \] **Update Worker Logic:** In `app/worker.py`, modify the call to `evaluate_content` to handle the returned Pydantic object directly (e.g., using `result.model_dump_json()` if a JSON string is needed downstream).
+  * Update the function's return type hint to `-> AnalysisResult`.
+* [x] **Update Worker Logic:** In `app/worker.py`, modify the call to `evaluate_content` to handle the returned Pydantic object directly (e.g., using `result.model_dump_json()` if a JSON string is needed downstream).
 
 ### **User Story 3: Implement Intelligent Error Handling (Estimated Time: 30 minutes)**
 
@@ -248,9 +248,9 @@ This epic covers all work required to ensure the data received from the OpenAI A
 * A log message is generated when a retry occurs.
 
 **TODOs:**
-* \[ \] **Enable Automatic Retries:** In `app/openai_evaluator.py`, add the `max_retries=2` parameter to the `client.chat.completions.create` call.  
-* \[ \] **Add Logging:** Implement basic logging within `evaluate_content` to capture and report when `instructor` performs a retry, which can be useful for monitoring the LLM's consistency.  
-* \[ \] **(Stretch Goal) Implement Final Safety Net:** For maximum robustness, create the `repair_json_with_llm` function from the research document and add it as a final `except` block to handle cases where even retries fail.
+* [x] **Enable Automatic Retries:** In `app/openai_evaluator.py`, add the `max_retries=2` parameter to the `client.chat.completions.create` call.
+* [x] **Add Logging:** Implement basic logging within `evaluate_content` to capture and report when `instructor` performs a retry, which can be useful for monitoring the LLM's consistency.
+* [x] **(Stretch Goal) Implement Final Safety Net:** For maximum robustness, create the `repair_json_with_llm` function from the research document and add it as a final `except` block to handle cases where even retries fail.
 
 
 ## General TODOs

--- a/app/models.py
+++ b/app/models.py
@@ -1,9 +1,10 @@
 from datetime import datetime
-from typing import Optional
+from typing import List, Literal, Optional
 
 from sqlalchemy import Column
 from sqlalchemy.dialects.postgresql import JSONB
 from sqlmodel import Field, SQLModel
+from pydantic import BaseModel, Field as PydanticField
 
 class AgentRun(SQLModel, table=True):
     """Table to track each agent execution."""
@@ -23,3 +24,36 @@ class Feedback(SQLModel, table=True):
     run_id: int = Field(foreign_key="agentrun.id")
     value: str
     submitted_at: datetime = Field(default_factory=datetime.utcnow, nullable=False)
+
+
+class SentimentAnalysis(BaseModel):
+    """Overall sentiment analysis results."""
+
+    overall_sentiment: Literal["positive", "neutral", "negative"] = PydanticField(
+        description="Categorical sentiment assessment"
+    )
+    score: float = PydanticField(
+        description="Numerical sentiment score where 1 is most positive"
+    )
+
+
+class Entity(BaseModel):
+    """Named entity extracted from the text."""
+
+    name: str = PydanticField(description="Entity name as found in the text")
+    type: str = PydanticField(description="Entity type such as person or brand")
+
+
+class AnalysisResult(BaseModel):
+    """Validated structure for AI-generated analysis output."""
+
+    summary: str = PydanticField(description="Concise summary of the content")
+    sentiment: SentimentAnalysis = PydanticField(
+        description="Sentiment analysis details"
+    )
+    entities: List[Entity] = PydanticField(
+        default_factory=list,
+        description="Entities mentioned in the content",
+    )
+
+

--- a/app/openai_evaluator.py
+++ b/app/openai_evaluator.py
@@ -1,10 +1,12 @@
-import json
-from typing import Dict, Any, Optional
+from typing import Any, Dict, Optional
 
-import openai
+import instructor
+from openai import AsyncOpenAI
+from instructor.client import HookName
 import structlog
 
 from .config import get_settings
+from .models import AnalysisResult
 
 log = structlog.get_logger()
 
@@ -15,13 +17,50 @@ if not OPENAI_API_KEY:
         "OPENAI_API_KEY environment variable is not set. OpenAI API calls may fail."
     )
 
-openai.api_key = OPENAI_API_KEY
+client = instructor.from_openai(AsyncOpenAI(api_key=OPENAI_API_KEY))
+
+def _log_retry(event: Exception) -> None:
+    """Log when instructor triggers a retry due to an error."""
+
+    log.warning("Retry triggered", error=str(event))
+
+
+client.on(HookName.PARSE_ERROR, _log_retry)
+client.on(HookName.COMPLETION_ERROR, _log_retry)
+client.on(
+    HookName.COMPLETION_LAST_ATTEMPT,
+    lambda e: log.error("All retries exhausted", error=str(e)),
+)
+
+
+async def repair_json_with_llm(text: str) -> Optional[AnalysisResult]:
+    """Attempt to repair invalid JSON using the LLM itself."""
+
+    log.info("Attempting to repair JSON with LLM")
+    try:
+        return await client.chat.completions.create(
+            model="gpt-3.5-turbo-0125",
+            messages=[
+                {
+                    "role": "system",
+                    "content": (
+                        "Fix the JSON so it conforms to the AnalysisResult schema."
+                    ),
+                },
+                {"role": "user", "content": text},
+            ],
+            temperature=0.0,
+            response_model=AnalysisResult,
+        )
+    except Exception as exc:  # pragma: no cover - network failures
+        log.error("Repair attempt failed", error=str(exc))
+    return None
 
 async def evaluate_content(
     text: str,
     brand_config: Dict[str, Any],
     task_type: str = "brand_health",
-) -> Optional[Dict[str, Any]]:
+) -> Optional[AnalysisResult]:
     """Evaluate text with OpenAI using brand-specific context.
 
     The ``task_type`` determines whether the analysis focuses on
@@ -69,20 +108,20 @@ Provide your response in JSON with the following fields:
 """
 
     try:
-        response = await openai.ChatCompletion.acreate(
+        response = await client.chat.completions.create(
             model="gpt-3.5-turbo-0125",
             messages=[
                 {"role": "system", "content": "You only respond in JSON."},
                 {"role": "user", "content": prompt},
             ],
-            response_format={"type": "json_object"},
             temperature=0.2,
+            response_model=AnalysisResult,
+            max_retries=2,
         )
-        return json.loads(response.choices[0].message.content)
-    except openai.error.OpenAIError as exc:
-        log.error("OpenAI API error during evaluation", error=str(exc))
-    except json.JSONDecodeError as exc:
-        log.error("Failed to parse OpenAI response as JSON", error=str(exc))
+        return response
     except Exception as exc:
-        log.error("Unexpected error during OpenAI evaluation", error=str(exc))
+        log.error("OpenAI API error during evaluation", error=str(exc))
+        repaired = await repair_json_with_llm(text)
+        if repaired:
+            return repaired
     return None

--- a/app/worker.py
+++ b/app/worker.py
@@ -83,11 +83,12 @@ def run_agent_logic(run_id: int, search_request: dict | None = None) -> None:
                 evaluate_content(page["text"], brand_config, task_type)
             )
             if result:
-                result["url"] = page.get("url")
+                result_dict = result.model_dump()
+                result_dict["url"] = page.get("url")
                 if task_type == "market_intelligence":
-                    market_evals.append(result)
+                    market_evals.append(result_dict)
                 else:
-                    brand_evals.append(result)
+                    brand_evals.append(result_dict)
 
     if search_request:
         brand_queries = search_request.get("brand_health_queries") or []

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,21 @@
+# For the web server and API
+fastapi
+uvicorn[standard]
+
+# For the database connection
+sqlalchemy
+psycopg2-binary
+
+# For the web scraper
+requests
+beautifulsoup4
+
+# For the AI evaluator
+openai
+instructor
+
+# For the email service
+python-dotenv
+
+# For testing
+pytest

--- a/tests/test_end_to_end.py
+++ b/tests/test_end_to_end.py
@@ -1,8 +1,10 @@
+import os
 import types
 from sqlmodel import SQLModel, Session, create_engine
 from sqlalchemy.pool import StaticPool
 
-from app.models import AgentRun
+os.environ["OPENAI_API_KEY"] = "test"
+from app.models import AgentRun, AnalysisResult, SentimentAnalysis
 from sqlalchemy.types import JSON
 import app.database as database
 import app.worker as worker
@@ -24,7 +26,11 @@ def test_end_to_end(monkeypatch):
     monkeypatch.setattr(scraper.SimpleScraper, "crawl", lambda self, terms: [{"url": "http://example.com", "text": "pizza"}])
 
     async def fake_eval(text, config, task_type):
-        return {"summary": "great"}
+        return AnalysisResult(
+            summary="great",
+            sentiment=SentimentAnalysis(overall_sentiment="positive", score=0.9),
+            entities=[],
+        )
     monkeypatch.setattr(worker, "evaluate_content", fake_eval)
 
     sent = {}

--- a/tests/test_openai_evaluator.py
+++ b/tests/test_openai_evaluator.py
@@ -1,19 +1,17 @@
-import json
-import types
+import os
 import pytest
 
+os.environ["OPENAI_API_KEY"] = "test"
 from app import openai_evaluator
+from app.models import AnalysisResult, SentimentAnalysis
 
-class DummyChoice:
-    def __init__(self, content):
-        self.message = types.SimpleNamespace(content=content)
 
-class DummyResponse:
-    def __init__(self, content):
-        self.choices = [DummyChoice(content)]
-
-async def dummy_acreate(*args, **kwargs):
-    return DummyResponse(json.dumps({"summary": "ok"}))
+async def dummy_create(*args, **kwargs):
+    return AnalysisResult(
+        summary="ok",
+        sentiment=SentimentAnalysis(overall_sentiment="positive", score=0.9),
+        entities=[],
+    )
 
 @pytest.mark.asyncio
 async def test_evaluate_content(monkeypatch):
@@ -24,9 +22,48 @@ async def test_evaluate_content(monkeypatch):
         "tone": {"persona": "friendly", "style_guide": "casual"},
     }
     monkeypatch.setattr(openai_evaluator, "OPENAI_API_KEY", "test")
-    monkeypatch.setattr(openai_evaluator.openai.ChatCompletion, "acreate", dummy_acreate)
+    monkeypatch.setattr(
+        openai_evaluator.client.chat.completions, "create", dummy_create
+    )
 
     result = await openai_evaluator.evaluate_content(
         "sample text", brand_config, "brand_health"
     )
-    assert result == {"summary": "ok"}
+    assert isinstance(result, AnalysisResult)
+    assert result.summary == "ok"
+
+
+@pytest.mark.asyncio
+async def test_evaluate_content_repair(monkeypatch):
+    brand_config = {
+        "display_name": "TestBrand",
+        "keywords": {"core": ["pizza"], "extended": ["culture"]},
+        "banned_words": ["foo"],
+        "tone": {"persona": "friendly", "style_guide": "casual"},
+    }
+
+    async def failing_create(*args, **kwargs):
+        assert kwargs.get("max_retries") == 2
+        raise Exception("bad json")
+
+    async def dummy_repair(text: str):
+        return AnalysisResult(
+            summary="fixed",
+            sentiment=SentimentAnalysis(overall_sentiment="positive", score=1.0),
+            entities=[],
+        )
+
+    monkeypatch.setattr(openai_evaluator, "OPENAI_API_KEY", "test")
+    monkeypatch.setattr(
+        openai_evaluator.client.chat.completions,
+        "create",
+        failing_create,
+    )
+    monkeypatch.setattr(openai_evaluator, "repair_json_with_llm", dummy_repair)
+
+    result = await openai_evaluator.evaluate_content(
+        "sample text",
+        brand_config,
+        "brand_health",
+    )
+    assert result.summary == "fixed"


### PR DESCRIPTION
## Summary
- log retries from `instructor` in `openai_evaluator`
- add automatic retries and final JSON repair step
- mark User Story 3 tasks as complete in README
- adjust tests for new retry behavior and set API key during import

## Testing
- `DATABASE_URL=sqlite:///test.db pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_686c8f155d088326b0d681422d5cd658