### PR TITLE
Add API port mapping

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,6 +4,8 @@ services:
   api:
     build: .
     command: uvicorn app.main:app --host 0.0.0.0 --port 8000
+    ports:
+      - "8008:8000"
     volumes:
       - .:/app
     environment:


### PR DESCRIPTION
## Summary
- expose API service on port 8008 in `docker-compose.yml`

## Testing
- `pip install -r requirements.txt`
- `pytest -q` *(fails: ValidationError for Settings)*

------
https://chatgpt.com/codex/tasks/task_b_686ca47c62908326a0cad0a283cb7fc1