### PR TITLE
Improve agent error handling

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,0 +1,1 @@
+from .agent import run_agent_iteration

--- a/app/agent.py
+++ b/app/agent.py
@@ -1,0 +1,13 @@
+import asyncio
+import structlog
+
+from .worker import run_agent_logic
+
+log = structlog.get_logger()
+
+async def run_agent_iteration(run_id: int, search_request: dict | None = None) -> None:
+    """Execute one iteration of the agent logic with robust error handling."""
+    try:
+        await asyncio.to_thread(run_agent_logic, run_id, search_request)
+    except Exception as exc:  # pragma: no cover - runtime safety
+        log.error("Agent iteration failed", run_id=run_id, error=str(exc), exc_info=True)

--- a/app/config.py
+++ b/app/config.py
@@ -1,5 +1,5 @@
 from functools import lru_cache
-from pydantic_settings import BaseSettings
+from pydantic_settings import BaseSettings, SettingsConfigDict
 from dotenv import load_dotenv
 
 load_dotenv()
@@ -14,9 +14,9 @@ class Settings(BaseSettings):
     brand_repo_path: str = "dev-research/debonair_brand.yaml"
     openai_api_key: str | None = None
 
-    class Config:
-        env_file = ".env"
-        env_file_encoding = "utf-8"
+    model_config = SettingsConfigDict(
+        env_file=".env", env_file_encoding="utf-8", extra="ignore"
+    )
 
 @lru_cache()
 def get_settings() -> Settings:


### PR DESCRIPTION
## Summary
- export `run_agent_iteration` via `app.__init__`
- add async `run_agent_iteration` function that wraps worker logic and logs errors
- ignore extra env vars in pydantic Settings so `.env` doesn't break tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_686ca5752fcc8326b290cb929ab7661a