### PR TITLE
Handle DuckDuckGo redirect links in scraper

### DIFF
--- a/tests/test_scraper.py
+++ b/tests/test_scraper.py
@@ -39,3 +39,13 @@ def test_simple_scraper_search_and_scrape(monkeypatch):
 
     text = s.scrape_page('http://example.com/1')
     assert text == 'Hello\nWorld'
+
+
+def test_simple_scraper_redirect_resolution(monkeypatch):
+    html = '<a class="result__a" href="/l/?uddg=http%3A%2F%2Fexample.com">Link</a>'
+    s = scraper.SimpleScraper()
+
+    monkeypatch.setattr(s, '_get', lambda url: html)
+
+    links = s.search('test', max_results=1)
+    assert links == ['http://example.com']


### PR DESCRIPTION
## Summary
- resolve relative links in scraper using `urllib.parse.urljoin`
- follow DuckDuckGo `/l/` redirects and return the final URL
- allow scheme-less URLs by prefixing with https
- test redirect handling in the scraper

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_686cf25990e883269d979e0b48ae33bd