### PR TITLE
Add search_config.json support

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ An automated backend for running AI agents on a schedule. It scrapes the web usi
 
 ## Configuration
 
-All configuration values are read from environment variables. See `.env.example` for reference. Typical variables include `DATABASE_URL`, `LOG_LEVEL`, `REDIS_URL`, `AGENT_RUN_INTERVAL_MINUTES`, and `OPENAI_API_KEY` for the scheduler frequency and API access. To customize scraping queries, copy `search_config.json.example` to `search_config.json` and adjust the `brand_health_queries` and `market_intelligence_queries` lists.
+ All configuration values are read from environment variables. See `.env.example` for reference. Typical variables include `DATABASE_URL`, `LOG_LEVEL`, `REDIS_URL`, `AGENT_RUN_INTERVAL_MINUTES`, and `OPENAI_API_KEY` for the scheduler frequency and API access. To customize scraping queries, copy `search_config.json.example` to `search_config.json` and adjust the `brand_health_queries` and `market_intelligence_queries` lists. When present, this file is automatically loaded by the worker to override dynamically generated search terms.
 
 ## Architecture
 

--- a/app/worker.py
+++ b/app/worker.py
@@ -39,6 +39,8 @@ def load_search_config(config_path: str = "search_config.json") -> dict | None:
 def run_agent_logic(run_id: int, search_request: dict | None = None) -> None:
     """Execute the agent iteration synchronously for RQ."""
     log.info("Executing agent logic", run_id=run_id)
+    if search_request is None:
+        search_request = load_search_config() or None
     asyncio.run(run_agent_iteration(run_id, search_request))
 
 

--- a/tests/test_worker_config.py
+++ b/tests/test_worker_config.py
@@ -1,0 +1,27 @@
+import json
+import os
+import app.worker as worker
+
+
+def test_run_agent_logic_loads_search_config(tmp_path, monkeypatch):
+    config = {
+        "brand_health_queries": ["foo"],
+        "market_intelligence_queries": ["bar"],
+    }
+    path = tmp_path / "search_config.json"
+    path.write_text(json.dumps(config))
+    monkeypatch.chdir(tmp_path)
+
+    captured = {}
+
+    async def fake_run_agent_iteration(run_id, search_request=None):
+        captured["run_id"] = run_id
+        captured["search_request"] = search_request
+
+    monkeypatch.setattr(worker, "run_agent_iteration", fake_run_agent_iteration)
+
+    worker.run_agent_logic(1)
+
+    assert captured["run_id"] == 1
+    assert captured["search_request"] == config
+


### PR DESCRIPTION
## Summary
- automatically load `search_config.json` in `run_agent_logic`
- document that search_config.json overrides dynamic terms
- test that the worker passes config to the agent when present

## Testing
- `pip install -q -r requirements.txt`
- `export OPENAI_API_KEY="test"`
- `export DATABASE_URL="sqlite+aiosqlite://"`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_686cf49c3cbc8326b7c683e19c528d88