### PR TITLE
Implement visit gating for scraper

### DIFF
--- a/tests/test_scraper.py
+++ b/tests/test_scraper.py
@@ -1,6 +1,12 @@
 import pytest
+import asyncio
+from sqlmodel import SQLModel, Session, select
+from sqlalchemy.ext.asyncio import create_async_engine, async_sessionmaker
+from sqlmodel.ext.asyncio.session import AsyncSession
+from sqlalchemy.pool import StaticPool
 
-from app import scraper
+from app import scraper, database
+from app.models import VisitedUrl
 
 
 def test_generate_search_terms():
@@ -49,3 +55,40 @@ def test_simple_scraper_redirect_resolution(monkeypatch):
 
     links = s.search('test', max_results=1)
     assert links == ['http://example.com']
+
+
+def test_crawl_records_and_skips(monkeypatch):
+    engine = create_async_engine(
+        "sqlite+aiosqlite://",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    async_session_local = async_sessionmaker(
+        engine, expire_on_commit=False, class_=AsyncSession
+    )
+
+    async def init_models():
+        async with engine.begin() as conn:
+            await conn.run_sync(SQLModel.metadata.create_all)
+
+    asyncio.run(init_models())
+
+    database.engine = engine
+    database.async_session = async_session_local
+    scraper.engine = engine
+
+    s = scraper.SimpleScraper()
+
+    monkeypatch.setattr(s, "search", lambda term, max_results=5: ["http://example.com"])
+    monkeypatch.setattr(s, "scrape_page", lambda url: "hi")
+
+    pages = s.crawl(["test"], max_results=1)
+    assert pages == [{"url": "http://example.com", "text": "hi"}]
+
+    pages2 = s.crawl(["test"], max_results=1)
+    assert pages2 == []
+
+    with Session(engine.sync_engine) as session:
+        rows = session.exec(select(VisitedUrl)).all()
+        assert len(rows) == 1
+        assert rows[0].domain == "example.com"


### PR DESCRIPTION
## Summary
- update scraper imports for DB session handling
- add a `_get_domain` helper
- check `VisitedUrl` table before scraping a link
- record successful visits after scraping
- test that crawl skips previously visited domains

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'structlog')*

------
https://chatgpt.com/codex/tasks/task_b_686d024ff5188326923bbdfc46025952