### PR TITLE
Implement snappy headings and URL shortener

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,7 @@
+# Example environment variables
+DATABASE_URL=postgresql://user:pass@localhost:5432/db
+LOG_LEVEL=INFO
+REDIS_URL=redis://localhost:6379/0
+AGENT_RUN_INTERVAL_MINUTES=600
+OPENAI_API_KEY=
+

--- a/app/agent.py
+++ b/app/agent.py
@@ -163,17 +163,24 @@ async def run_agent_iteration(run_id: int, search_request: dict | None = None) -
             url = item["url"]
             snippet = item["snippet"].lower()
             score = item["evaluation"].get("relevance_score", 0)
+            heading = item["evaluation"].get("snappy_heading", "")
 
             if any(term in snippet for term in brand_terms):
-                on_brand_specific_items.append({"url": url, "score": score})
+                on_brand_specific_items.append({"url": url, "score": score, "snappy_heading": heading})
             else:
-                brand_relevant_items.append({"url": url, "score": score})
+                brand_relevant_items.append({"url": url, "score": score, "snappy_heading": heading})
 
         on_brand_specific_items.sort(key=lambda x: x["score"], reverse=True)
         brand_relevant_items.sort(key=lambda x: x["score"], reverse=True)
 
-        on_brand_specific_links = [i["url"] for i in on_brand_specific_items[:max_email_links]]
-        brand_relevant_links = [i["url"] for i in brand_relevant_items[:max_email_links]]
+        on_brand_specific_links = [
+            {"url": i["url"], "snappy_heading": i.get("snappy_heading", "")}
+            for i in on_brand_specific_items[:max_email_links]
+        ]
+        brand_relevant_links = [
+            {"url": i["url"], "snappy_heading": i.get("snappy_heading", "")}
+            for i in brand_relevant_items[:max_email_links]
+        ]
 
         content_summaries = [
             item["evaluation"].get("summary", "")

--- a/app/email_sender.py
+++ b/app/email_sender.py
@@ -47,11 +47,12 @@ class EmailSender:
                 receiver_email=bool(self.receiver_email),
             )
 
+
     def _build_html(
         self,
         run_id: int,
-        on_brand_specific_links: list[str] | None = None,
-        brand_relevant_links: list[str] | None = None,
+        on_brand_specific_links: list[dict] | None = None,
+        brand_relevant_links: list[dict] | None = None,
         brand_system_prompt: str | None = None,
         market_system_prompt: str | None = None,
         user_prompt: str | None = None,
@@ -62,20 +63,22 @@ class EmailSender:
     ) -> str:
         """Return HTML body for the summary email using the new template."""
 
-        def list_links(links: list[str] | None, include_feedback: bool = False) -> str:
+        def list_links(links: list[dict] | None, include_feedback: bool = False) -> str:
             if not links:
                 return "<li>No links found.</li>"
             items = []
-            for link in links:
+            for item in links:
+                url = item.get("url")
+                heading = item.get("snappy_heading", url)
                 feedback = (
                     (
-                        f" - <a href='http://localhost:8000/feedback?run_id={run_id}&feedback=yes'>Yes, it was helpful!</a> | "
-                        f"<a href='http://localhost:8000/feedback?run_id={run_id}&feedback=no'>No, it was not helpful.</a>"
+                        f" - <a href='http://localhost:8000/feedback?run_id={run_id}&feedback=yes'>Yes 👍, it was helpful!</a> | "
+                        f"<a href='http://localhost:8000/feedback?run_id={run_id}&feedback=no'>No👎, it was not helpful.</a>"
                     )
                     if include_feedback
                     else ""
                 )
-                items.append(f"<li><a href='{link}'>{link}</a>{feedback}</li>")
+                items.append(f"<li><a href='{url}'>{heading}</a>{feedback}</li>")
             return "".join(items)
 
         def list_str(values: list[str] | None) -> str:
@@ -96,9 +99,9 @@ class EmailSender:
             "<html>",
             "<body style='font-family: Arial, sans-serif; line-height:1.4;'>",
             f"<h3>Hi there</h3>",
-            "<h3>Below are links that the AI thinks are on brand specific</h3>",
+            "<h3><strong>Below are links that the AI thinks are on brand specific</strong></h3>",
             f"<ul>{list_links(on_brand_specific_links, include_feedback=True)}</ul>",
-            "<h3>Below are 3 links that AI thinks are brand relevant but not brand specific</h3>",
+            "<h3><strong>Below are 3 links that AI thinks are brand relevant but not brand specific</strong></h3>",
             f"<ul>{list_links(brand_relevant_links)}</ul>",
             "<h3>Prompt Engineering Metadata</h3>",
             f"<p><strong>Brand System Prompt:</strong> {truncate(brand_system_prompt)}</p>",
@@ -119,8 +122,8 @@ class EmailSender:
         self,
         run_id: int,
         *,
-        on_brand_specific_links: list[str] | None = None,
-        brand_relevant_links: list[str] | None = None,
+        on_brand_specific_links: list[dict] | None = None,
+        brand_relevant_links: list[dict] | None = None,
         brand_system_prompt: str | None = None,
         market_system_prompt: str | None = None,
         user_prompt: str | None = None,

--- a/app/models.py
+++ b/app/models.py
@@ -57,6 +57,9 @@ class AnalysisResult(BaseModel):
     """Validated structure for AI-generated analysis output."""
 
     summary: str = PydanticField(description="Concise summary of the content")
+    snappy_heading: str = PydanticField(
+        description="A concise, engaging title for the content, suitable for a link or headline."
+    )
     sentiment: SentimentAnalysis = PydanticField(
         description="Sentiment analysis details"
     )

--- a/app/openai_evaluator.py
+++ b/app/openai_evaluator.py
@@ -87,7 +87,7 @@ def _construct_prompt_messages(
         f"You are an expert assistant analyzing text for {brand_config.get('display_name', '')}. "
         f"Use a {persona} {style} tone. {focus_line} "
         f"Keywords to monitor: {all_keywords}. Avoid these banned words: {banned_words}. "
-        "Respond in JSON only."
+        "Respond in JSON only. Also generate a 'snappy_heading' field: a short, engaging title for the content, ideal for a clickable link."
     )
 
     examples_key = (

--- a/tests/test_email_sender.py
+++ b/tests/test_email_sender.py
@@ -48,8 +48,8 @@ def test_send_summary_email(monkeypatch):
 
     sender.send_summary_email(
         run_id=1,
-        on_brand_specific_links=["http://brand.com"],
-        brand_relevant_links=["http://relevant.com"],
+        on_brand_specific_links=[{"url": "http://brand.com", "snappy_heading": "Brand"}],
+        brand_relevant_links=[{"url": "http://relevant.com", "snappy_heading": "Relevant"}],
         brand_system_prompt="brand",
         market_system_prompt="market",
         user_prompt="user",
@@ -63,9 +63,9 @@ def test_send_summary_email(monkeypatch):
     assert dummy.logged_in == ("user", "pass")
     assert dummy.sent
     assert isinstance(dummy.sent_msg, MIMEMultipart)
-    body = dummy.sent_msg.as_string()
-    assert "on brand specific" in body
-    assert "brand relevant but not brand specific" in body
-    assert "Brand System Prompt" in body
-    assert "Number of Search Calls" in body
+    body_raw = dummy.sent_msg.get_payload()[0].get_payload(decode=True).decode()
+    assert "on brand specific" in body_raw
+    assert "brand relevant but not brand specific" in body_raw
+    assert "Brand System Prompt" in body_raw
+    assert "Number of Search Calls" in body_raw
 

--- a/tests/test_end_to_end.py
+++ b/tests/test_end_to_end.py
@@ -50,6 +50,7 @@ def test_end_to_end(monkeypatch):
     async def fake_eval(snippet, config, task_type):
         return AnalysisResult(
             summary="great",
+            snappy_heading="Great",
             sentiment=SentimentAnalysis(overall_sentiment="positive", score=0.9),
             entities=[],
             relevance_score=80.0,

--- a/tests/test_openai_evaluator.py
+++ b/tests/test_openai_evaluator.py
@@ -10,6 +10,7 @@ from app.models import AnalysisResult, SentimentAnalysis
 async def dummy_create(*args, **kwargs):
     return AnalysisResult(
         summary="ok",
+        snappy_heading="Great heading",
         sentiment=SentimentAnalysis(overall_sentiment="positive", score=0.9),
         entities=[],
         relevance_score=100.0,
@@ -34,6 +35,7 @@ async def test_evaluate_content(monkeypatch):
     )
     assert isinstance(result, AnalysisResult)
     assert result.summary == "ok"
+    assert result.snappy_heading == "Great heading"
 
 
 @pytest.mark.asyncio
@@ -52,6 +54,7 @@ async def test_evaluate_content_repair(monkeypatch):
     async def dummy_repair(text: str):
         return AnalysisResult(
             summary="fixed",
+            snappy_heading="Fixed heading",
             sentiment=SentimentAnalysis(overall_sentiment="positive", score=1.0),
             entities=[],
             relevance_score=90.0,
@@ -72,4 +75,5 @@ async def test_evaluate_content_repair(monkeypatch):
         "brand_health",
     )
     assert result.summary == "fixed"
+    assert result.snappy_heading == "Fixed heading"
 


### PR DESCRIPTION
## Summary
- extend `AnalysisResult` with a new `snappy_heading` field
- instruct OpenAI prompt to return the heading
- track and pass headings in the agent
- remove TinyURL-based shortener; keep links in full
- tweak HTML headings and feedback text
- expose `.env` variables for clarity
- update tests for new structures

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_686d3a834ca083268ec194d5abc242ab