### PR TITLE
Add rotating search phrases and blacklist domains

### DIFF
--- a/search_config.json
+++ b/search_config.json
@@ -10,6 +10,16 @@
     "emerging competitor ",
     "new technology",
     "impact of regulation"
+  ],
+  "blacklisted_domains": [
+    "wikipedia.org",
+    "yourbrandhomepage.com"
+  ],
+  "rotating_search_phrases": [
+    "latest news",
+    "breakthrough",
+    "analysis",
+    "case study"
   ]
 }
 

--- a/tests/test_end_to_end.py
+++ b/tests/test_end_to_end.py
@@ -41,11 +41,10 @@ def setup_module(module):
 
 
 def test_end_to_end(monkeypatch):
-    monkeypatch.setattr(
-        scraper.SimpleScraper,
-        "crawl",
-        lambda self, terms: [{"url": "http://example.com", "snippet": "pizza"}],
-    )
+    async def fake_crawl(self, session, terms, max_results=5):
+        return [{"url": "http://example.com", "snippet": "pizza"}]
+
+    monkeypatch.setattr(scraper.SimpleScraper, "crawl", fake_crawl)
 
     async def fake_eval(snippet, config, task_type):
         return AnalysisResult(

--- a/tests/test_scraper.py
+++ b/tests/test_scraper.py
@@ -21,7 +21,11 @@ def test_load_brand_keywords():
     assert 'interactive' in keywords
 
 
-def test_simple_scraper_search_and_crawl(monkeypatch):
+import asyncio
+
+
+@pytest.mark.asyncio
+async def test_simple_scraper_search_and_crawl(monkeypatch):
     class Dummy:
         def __init__(self, url, title, description):
             self.url = url
@@ -36,10 +40,13 @@ def test_simple_scraper_search_and_crawl(monkeypatch):
         ]
 
     monkeypatch.setattr(scraper, 'google_search', fake_search)
+    async def fake_is_url_visited(self, session, url):
+        return False
+    monkeypatch.setattr(scraper.SimpleScraper, '_is_url_visited', fake_is_url_visited)
 
     s = scraper.SimpleScraper()
 
-    results = s.search('test', max_results=2)
+    results = await s.search(None, 'test', max_results=2)
     assert results == [
         {
             'url': 'http://example.com/1',
@@ -55,11 +62,12 @@ def test_simple_scraper_search_and_crawl(monkeypatch):
         },
     ]
 
-    pages = s.crawl(['test'], max_results=2)
+    pages = await s.crawl(None, ['test'], max_results=2)
     assert pages == results
 
 
-def test_simple_scraper_skips_invalid_results(monkeypatch):
+@pytest.mark.asyncio
+async def test_simple_scraper_skips_invalid_results(monkeypatch):
     class Dummy:
         def __init__(self, url, title, description):
             self.url = url
@@ -74,9 +82,12 @@ def test_simple_scraper_skips_invalid_results(monkeypatch):
         ]
 
     monkeypatch.setattr(scraper, 'google_search', fake_search)
+    async def fake_is_url_visited(self, session, url):
+        return False
+    monkeypatch.setattr(scraper.SimpleScraper, '_is_url_visited', fake_is_url_visited)
 
     s = scraper.SimpleScraper()
-    results = s.search('whatever', max_results=3)
+    results = await s.search(None, 'whatever', max_results=3)
     assert results == [
         {
             'url': 'http://ok.com',


### PR DESCRIPTION
## Summary
- extend `search_config.json` with example blacklist and rotating search phrases
- load search configuration in `SimpleScraper`
- filter results based on blacklisted and visited URLs
- update `agent` and tests for async crawling
- handle visited URLs using the database session
- generate queries with rotating search phrases

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_686d3f78899c8326bc67421f46728fc4