### PR TITLE
Add rotating search phrases for market queries

### DIFF
--- a/search_config.json
+++ b/search_config.json
@@ -10,6 +10,10 @@
     "emerging competitor ",
     "new technology",
     "impact of regulation"
+  ],
+  "rotating_search_phrases": [
+    "industry report",
+    "market analysis"
   ]
 }
 

--- a/search_config.json.example
+++ b/search_config.json.example
@@ -9,7 +9,11 @@
     "industry trends 2024",
     "emerging competitor strategies",
     "new technology in [industry]",
-  "impact of regulation on [industry]"
+    "impact of regulation on [industry]"
+  ],
+  "rotating_search_phrases": [
+    "industry report",
+    "market analysis"
   ],
   "max_email_links": 10
 }

--- a/tests/test_agent_market_queries.py
+++ b/tests/test_agent_market_queries.py
@@ -1,0 +1,85 @@
+import os
+import asyncio
+import random
+from sqlmodel import SQLModel
+from sqlalchemy.ext.asyncio import create_async_engine, async_sessionmaker
+from sqlmodel.ext.asyncio.session import AsyncSession
+from sqlalchemy.pool import StaticPool
+from sqlalchemy.types import JSON
+
+os.environ.setdefault("DATABASE_URL", "sqlite+aiosqlite://")
+os.environ.setdefault("OPENAI_API_KEY", "test")
+
+import app.database as database
+from app.models import AgentRun, AnalysisResult, SentimentAnalysis
+from app.agent import run_agent_iteration
+from app import scraper, worker, email_sender
+
+engine = create_async_engine(
+    "sqlite+aiosqlite://",
+    connect_args={"check_same_thread": False},
+    poolclass=StaticPool,
+)
+async_session_local = async_sessionmaker(engine, expire_on_commit=False, class_=AsyncSession)
+AgentRun.__table__.c.result.type = JSON()
+
+async def init_models():
+    async with engine.begin() as conn:
+        await conn.run_sync(SQLModel.metadata.create_all)
+
+asyncio.run(init_models())
+
+database.engine = engine
+database.async_session = async_session_local
+worker.engine = engine
+worker.async_session = async_session_local
+
+
+def test_market_queries_mix(monkeypatch):
+    monkeypatch.setattr(random, "sample", lambda seq, k: list(seq)[:k])
+
+    captured_terms = []
+
+    def fake_crawl(self, terms, max_results=5):
+        captured_terms.append(list(terms))
+        return [{"url": "http://example.com", "snippet": "pizza"}]
+
+    monkeypatch.setattr(scraper.SimpleScraper, "crawl", fake_crawl)
+
+    async def fake_eval(snippet, config, task_type):
+        return AnalysisResult(
+            summary="ok",
+            snappy_heading="H",
+            sentiment=SentimentAnalysis(overall_sentiment="positive", score=1.0),
+            entities=[],
+            relevance_score=90.0,
+            categories=["News"],
+        )
+
+    monkeypatch.setattr(worker, "evaluate_content", fake_eval)
+    monkeypatch.setattr(email_sender.EmailSender, "send_summary_email", lambda *a, **k: None)
+
+    async def create_run():
+        async with async_session_local() as session:
+            run = AgentRun(status="queued")
+            session.add(run)
+            await session.commit()
+            await session.refresh(run)
+            return run.id
+
+    run_id = asyncio.run(create_run())
+
+    search_request = {
+        "market_intelligence_queries": ["tech trend"],
+        "rotating_search_phrases": ["analysis"],
+        "max_search_terms_generated": 3,
+    }
+
+    asyncio.run(run_agent_iteration(run_id, search_request))
+
+    # only market queries were generated
+    assert captured_terms[0] == [
+        "pizza tech trend",
+        "pizza analysis",
+        "culture tech trend",
+    ]


### PR DESCRIPTION
## Summary
- support rotating search phrases from search_config.json
- mix brand keywords with market and rotating phrases when creating market queries
- document rotating search phrases in search_config.json and example
- test market query generation logic

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_686d4cce1f20832691539bd5eb887de5