### PR TITLE
Add daily email scheduler

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -9,13 +9,22 @@ class Settings(BaseSettings):
 
     DATABASE_URL: str  # This is the correct line
     # REMOVE the line below
-    # database_url: str = "sqlite:///./development.db" 
+    # database_url: str = "sqlite:///./development.db"
 
     log_level: str = "INFO"
     redis_url: str = "redis://localhost:6379/0"
     agent_run_interval_minutes: int = 60
     brand_repo_path: str = "dev-research/debonair_brand.yaml"
     openai_api_key: str | None = None
+    serpapi_api_key: str | None = None
+    email_recipient: str | None = None
+    email_sender: str | None = None
+    smtp_server: str | None = None
+    smtp_port: int | None = None
+    smtp_username: str | None = None
+    smtp_password: str | None = None
+    daily_email_hour: int = 6
+    daily_email_minute: int = 0
 
     model_config = SettingsConfigDict(
         env_file=".env", env_file_encoding="utf-8", extra="ignore"

--- a/app/worker.py
+++ b/app/worker.py
@@ -10,6 +10,7 @@ from .config import get_settings
 from .database import engine
 from .agent import run_agent_iteration
 from .openai_evaluator import evaluate_content
+from .daily_email_compiler import compile_and_send_daily_email as compile_daily_email
 import structlog
 
 # Configure logging for better visibility
@@ -48,6 +49,12 @@ def run_agent_logic(run_id: int, search_request: dict | None = None) -> None:
     if search_request is None:
         search_request = load_search_config()
     asyncio.run(run_agent_iteration(run_id, search_request))
+
+
+def compile_and_send_daily_email() -> None:
+    """Compile and send the daily market intelligence email."""
+    log.info("Starting daily email compilation and sending process")
+    asyncio.run(compile_daily_email())
 
 
 def run_worker() -> None:


### PR DESCRIPTION
## Summary
- configure daily email hour & minute via `Settings`
- schedule email compilation job with APScheduler CronTrigger
- implement worker function to run daily email task

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlmodel')*

------
https://chatgpt.com/codex/tasks/task_b_686d59484e58832687cb7770107862ac