### PR TITLE
Implement daily search cap

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -25,6 +25,8 @@ class Settings(BaseSettings):
     smtp_password: str | None = None
     daily_email_hour: int = 6
     daily_email_minute: int = 0
+    max_daily_searches: int = 90
+    app_base_url: str = "http://localhost:8000"
 
     model_config = SettingsConfigDict(
         env_file=".env", env_file_encoding="utf-8", extra="ignore"

--- a/app/email_sender.py
+++ b/app/email_sender.py
@@ -5,6 +5,8 @@ import structlog
 from email.mime.multipart import MIMEMultipart
 from email.mime.text import MIMEText
 
+from .config import get_settings
+
 log = structlog.get_logger()
 
 
@@ -67,13 +69,15 @@ class EmailSender:
             if not links:
                 return "<li>No links found.</li>"
             items = []
+            settings = get_settings()
+            base = settings.app_base_url.rstrip("/")
             for item in links:
                 url = item.get("url")
                 heading = item.get("snappy_heading", url)
                 feedback = (
                     (
-                        f" - <a href='http://localhost:8000/feedback?run_id={run_id}&feedback=yes'>Yes 👍, it was helpful!</a> | "
-                        f"<a href='http://localhost:8000/feedback?run_id={run_id}&feedback=no'>No👎, it was not helpful.</a>"
+                        f" - <a href='{base}/feedback?run_id={run_id}&feedback=yes'>Yes 👍, it was helpful!</a> | "
+                        f"<a href='{base}/feedback?run_id={run_id}&feedback=no'>No👎, it was not helpful.</a>"
                     )
                     if include_feedback
                     else ""

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ version: '3.9'
 services:
   api:
     build: .
-    command: uvicorn app.main:app --host 0.0.0.0 --port 8000
+    command: uvicorn app.main:app --host 0.0.0.0 --port $PORT
     ports:
       - "8008:8000"
     volumes:
@@ -16,7 +16,7 @@ services:
 
   worker:
     build: .
-    command: python -m app.worker
+    command: rq worker --url $REDIS_URL high default low
     volumes:
       - .:/app
     env_file:


### PR DESCRIPTION
## Summary
- add `max_daily_searches` setting in `Settings`
- track daily search count in `search_count.json`
- enforce cap via new `run_searches` helper in `agent`
- update search logic to record which queries actually ran
- add `app_base_url` config and use in feedback links
- adjust docker-compose commands for Render deployment
- skip crawling when no search terms

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_686e890ce5e48326b0b2ed4476d0cc0a