### PR TITLE
Improve email summary prompt

### DIFF
--- a/app/email_sender.py
+++ b/app/email_sender.py
@@ -72,8 +72,9 @@ class EmailSender:
             settings = get_settings()
             base = settings.app_base_url.rstrip("/")
             for item in links:
-                url = item.get("url")
-                heading = item.get("snappy_heading", url)
+                url = item.get("link") or item.get("url")
+                headline = item.get("headline") or item.get("snappy_heading", url)
+                emoji = item.get("emoji", "")
                 feedback = (
                     (
                         f" - <a href='{base}/feedback?run_id={run_id}&feedback=yes'>Yes 👍, it was helpful!</a> | "
@@ -82,7 +83,9 @@ class EmailSender:
                     if include_feedback
                     else ""
                 )
-                items.append(f"<li><a href='{url}'>{heading}</a>{feedback}</li>")
+                items.append(
+                    f"<li>{emoji} <a href='{url}'>{headline}</a>{feedback}</li>"
+                )
             return "".join(items)
 
         def list_str(values: list[str] | None) -> str:

--- a/tests/test_email_sender.py
+++ b/tests/test_email_sender.py
@@ -48,8 +48,8 @@ def test_send_summary_email(monkeypatch):
 
     sender.send_summary_email(
         run_id=1,
-        on_brand_specific_links=[{"url": "http://brand.com", "snappy_heading": "Brand"}],
-        brand_relevant_links=[{"url": "http://relevant.com", "snappy_heading": "Relevant"}],
+        on_brand_specific_links=[{"emoji": "\U0001F4A1", "headline": "Brand", "link": "http://brand.com"}],
+        brand_relevant_links=[{"emoji": "\U0001F3C6", "headline": "Relevant", "link": "http://relevant.com"}],
         brand_system_prompt="brand",
         market_system_prompt="market",
         user_prompt="user",


### PR DESCRIPTION
## Summary
- add `EvaluatedSnippet` pydantic model with emoji, headline and link fields
- implement `evaluate_snippets_for_brand_fit` using new concise prompt
- handle new format in email template
- summarize daily snippets with emoji headlines

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_686e9153ec848326980146403ea0f988