### PR TITLE
Add asyncpg dependency

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -21,3 +21,4 @@ googlesearch-python
 pytest
 pytest-asyncio
 pandas
+asyncpg

--- a/requirements.txt
+++ b/requirements.txt
@@ -25,7 +25,10 @@ apscheduler==3.11.0
 async-timeout==5.0.1
     # via
     #   aiohttp
+    #   asyncpg
     #   redis
+asyncpg==0.30.0
+    # via -r requirements.in
 attrs==25.3.0
     # via aiohttp
 babel==2.17.0


### PR DESCRIPTION
## Summary
- ensure Render installs asyncpg

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlmodel')*

------
https://chatgpt.com/codex/tasks/task_b_686f86cb94f48326a41cdf276332b7a7