### PR TITLE
Add psycopg2-binary

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -178,6 +178,8 @@ psycopg[binary]==3.2.9
     # via -r requirements.in
 psycopg-binary==3.2.9
     # via psycopg
+psycopg2-binary==2.9.10
+    # via -r requirements.in
 pydantic==2.11.7
     # via
     #   fastapi


### PR DESCRIPTION
## Summary
- add psycopg2-binary to the list of pinned packages

## Testing
- `pytest -q` *(fails: ImportError – SQLModel)*

------
https://chatgpt.com/codex/tasks/task_b_686f8f2ba7108326855c3555d8163537