### PR TITLE
Implement custom prompt params for /run-agent

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -180,3 +180,4 @@ cython_debug/
 .cursorignore
 .cursorindexingignore
 .env
+search_count.json

--- a/tests/test_agent_market_queries.py
+++ b/tests/test_agent_market_queries.py
@@ -46,7 +46,7 @@ def test_market_queries_mix(monkeypatch):
 
     monkeypatch.setattr(scraper.SimpleScraper, "crawl", fake_crawl)
 
-    async def fake_eval(snippet, config, task_type):
+    async def fake_eval(snippet, config, task_type, custom_params=None):
         return AnalysisResult(
             summary="ok",
             snappy_heading="H",

--- a/tests/test_end_to_end.py
+++ b/tests/test_end_to_end.py
@@ -46,7 +46,7 @@ def test_end_to_end(monkeypatch):
 
     monkeypatch.setattr(scraper.SimpleScraper, "crawl", fake_crawl)
 
-    async def fake_eval(snippet, config, task_type):
+    async def fake_eval(snippet, config, task_type, custom_params=None):
         return AnalysisResult(
             summary="great",
             snappy_heading="Great",


### PR DESCRIPTION
## Summary
- allow custom brand & market prompts via new `AgentRunParams`
- expose optional request body on `/run-agent`
- forward params to worker when enqueuing an agent run
- handle params in agent iteration and record them in summary emails
- support custom prompts in OpenAI evaluator

## Testing
- `pytest -q` *(fails: ModuleNotFoundError for dependencies)*

------
https://chatgpt.com/codex/tasks/task_b_686f9e0aff988326ae5d7193da1412aa