### PR TITLE
Brand-targeted queries and clearer no-news emails

### DIFF
--- a/app/agent.py
+++ b/app/agent.py
@@ -258,11 +258,22 @@ async def run_agent_iteration(
                         generated_fallback_queries.append(f"{kw} {random_phrase}")
                         if len(generated_fallback_queries) >= max_generated_terms:
                             break
-                brand_queries = generated_fallback_queries or ["latest news"]
+                brand_name = brand_config.get("display_name") or brand_id
+                brand_queries = generated_fallback_queries or [brand_name]
                 log.info(
                     "Using generated queries from keywords and rotating phrases as fallback",
                     num_queries=len(brand_queries),
                 )
+
+            # Ensure the brand name appears in at least two search queries
+            brand_name = brand_config.get("display_name") or brand_id
+            if brand_name:
+                brand_lower = brand_name.lower()
+                count = sum(1 for q in brand_queries if brand_lower in q.lower())
+                while count < 2:
+                    phrase = random.choice(rotating_phrases) if rotating_phrases else "news"
+                    brand_queries.append(f"{brand_name} {phrase}")
+                    count += 1
     
             async def crawl_terms(terms: List[str]) -> List[Dict[str, Any]]:
                 pages, executed_terms = await run_searches(scraper, session, terms)
@@ -430,6 +441,7 @@ async def run_agent_iteration(
                 num_search_calls=len(search_terms_generated),
                 search_times=search_times,
                 content_summaries=content_summaries,
+                brand_display_name=brand_config.get("display_name") or brand_id,
             )
     
         except Exception as exc:  # pragma: no cover - runtime safety

--- a/tests/test_agent_market_queries.py
+++ b/tests/test_agent_market_queries.py
@@ -37,6 +37,7 @@ worker.async_session = async_session_local
 
 def test_market_queries_mix(monkeypatch):
     monkeypatch.setattr(random, "sample", lambda seq, k: list(seq)[:k])
+    monkeypatch.setattr(random, "choice", lambda seq: seq[0])
 
     captured_terms = []
 
@@ -77,8 +78,12 @@ def test_market_queries_mix(monkeypatch):
 
     asyncio.run(run_agent_iteration(run_id, search_request))
 
-    # only market queries were generated
     assert captured_terms[0] == [
+        "Debonairs Pizza analysis",
+        "Debonairs Pizza analysis",
+    ]
+
+    assert captured_terms[1] == [
         "pizza tech trend",
         "pizza analysis",
         "culture tech trend",

--- a/tests/test_email_sender.py
+++ b/tests/test_email_sender.py
@@ -69,3 +69,24 @@ def test_send_summary_email(monkeypatch):
     assert "Brand System Prompt" in body_raw
     assert "Number of Search Calls" in body_raw
 
+
+def test_send_summary_email_no_news(monkeypatch):
+    dummy = DummySMTP("smtp.example.com", 587)
+    monkeypatch.setattr(smtplib, "SMTP", lambda server, port: dummy)
+
+    sender = EmailSender(
+        smtp_server="smtp.example.com",
+        smtp_port=587,
+        username="user",
+        password="pass",
+        sender_email="sender@example.com",
+        receiver_email="receiver@example.com",
+    )
+
+    sender.send_summary_email(run_id=2, on_brand_specific_links=[], brand_relevant_links=[], brand_display_name="Debonairs Pizza")
+
+    subject = dummy.sent_msg["Subject"]
+    body_raw = dummy.sent_msg.get_payload()[0].get_payload(decode=True).decode()
+    assert "No brand-specific or brand-relevant news was found for Debonairs Pizza today." in body_raw
+    assert subject == "Daily Summary: No News for Today"
+


### PR DESCRIPTION
## Summary
- ensure fallback search term uses the brand name
- guarantee at least two search queries mention the brand
- send clearer summary emails when no articles were found and change subject line
- adjust market query test expectations
- test no-news email scenario

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_686fb1b25ffc8326b121dd70ccf09141