### PR TITLE
Add BrandConfigForm Pydantic model

### DIFF
--- a/app/config_routes.py
+++ b/app/config_routes.py
@@ -1,0 +1,46 @@
+from fastapi import APIRouter, HTTPException
+import yaml
+import os
+import structlog
+
+from .models import BrandConfigForm
+from .config import get_settings
+
+router = APIRouter()
+log = structlog.get_logger(__name__)
+
+
+def _get_config_path() -> str:
+    settings = get_settings()
+    return getattr(settings, "brand_repo_path", "dev-research/debonair_brand.yaml")
+
+
+@router.get("/config")
+async def read_config():
+    """Return brand configuration from the YAML file as JSON."""
+    path = _get_config_path()
+    if not os.path.exists(path):
+        raise HTTPException(status_code=404, detail="Configuration file not found")
+    try:
+        with open(path, "r", encoding="utf-8") as f:
+            data = yaml.safe_load(f) or {}
+    except yaml.YAMLError:
+        log.error("Invalid YAML format", path=path)
+        raise HTTPException(status_code=500, detail="Invalid YAML format")
+    return data
+
+
+@router.post("/config")
+async def write_config(config: BrandConfigForm):
+    """Persist brand configuration back to the YAML file."""
+    path = _get_config_path()
+    try:
+        yaml_content = yaml.safe_dump(
+            config.dict(), allow_unicode=True, sort_keys=False
+        )
+        with open(path, "w", encoding="utf-8") as f:
+            f.write(yaml_content)
+    except Exception as exc:  # pragma: no cover - unexpected IO errors
+        log.error("Failed to write configuration", error=str(exc))
+        raise HTTPException(status_code=500, detail="Failed to update configuration")
+    return {"status": "ok"}

--- a/app/main.py
+++ b/app/main.py
@@ -17,6 +17,7 @@ from .config import get_settings
 from .database import get_session, init_db
 
 from .routes import router as api_router, admin_router
+from .config_routes import router as config_router
 from .models import AgentRun
 from .agent import run_agent_iteration
 
@@ -119,6 +120,7 @@ def on_shutdown() -> None:
 
 app.include_router(api_router)
 app.include_router(admin_router)  # Include the new admin router
+app.include_router(config_router)
 
 # Default root path
 @app.get("/")

--- a/app/models.py
+++ b/app/models.py
@@ -95,3 +95,25 @@ class EvaluatedSnippet(Base):
     timestamp = Column(DateTime, default=datetime.utcnow)
 
 
+class BrandConfigForm(BaseModel):
+    """Schema for submitting or editing brand configuration."""
+
+    display_name: str = PydanticField(
+        description="Human-friendly brand name as shown in the UI"
+    )
+    persona: str = PydanticField(
+        description="Short description of the brand persona"
+    )
+    tone: str = PydanticField(
+        description="Guidelines describing the brand tone or style"
+    )
+    keywords: List[str] = PydanticField(
+        default_factory=list,
+        description="Keywords associated with the brand"
+    )
+    banned_words: List[str] = PydanticField(
+        default_factory=list,
+        description="Words that should be avoided in generated content"
+    )
+
+

--- a/tests/test_config_routes.py
+++ b/tests/test_config_routes.py
@@ -1,0 +1,40 @@
+import os
+import yaml
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from app.config import get_settings
+
+from app import config_routes
+
+os.environ.setdefault("DATABASE_URL", "sqlite+aiosqlite://")
+os.environ.setdefault("OPENAI_API_KEY", "test")
+
+
+def test_config_endpoints(tmp_path, monkeypatch):
+    config_path = tmp_path / "brand.yaml"
+    initial = {"display_name": "X"}
+    config_path.write_text(yaml.safe_dump(initial))
+
+    monkeypatch.setenv("BRAND_REPO_PATH", str(config_path))
+    get_settings.cache_clear()
+
+    app = FastAPI()
+    app.include_router(config_routes.router)
+    client = TestClient(app)
+
+    resp = client.get("/config")
+    assert resp.status_code == 200
+    assert resp.json() == initial
+
+    new_data = {
+        "display_name": "New",
+        "persona": "cool",
+        "tone": "casual",
+        "keywords": ["a"],
+        "banned_words": ["b"],
+    }
+    resp = client.post("/config", json=new_data)
+    assert resp.status_code == 200
+    saved = yaml.safe_load(config_path.read_text())
+    assert saved == new_data


### PR DESCRIPTION
## Summary
- add `BrandConfigForm` in `app/models.py`
- include fields for display name, persona, tone, keywords and banned words
- expose brand YAML via new endpoints in `config_routes`
- wire new router into FastAPI app
- test configuration endpoints

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_686fb7ba8ff4832694d1f68515a27685