### PR TITLE
Add config form UI

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -1,7 +1,15 @@
 import logging
 import sys
 
-from fastapi import FastAPI, Depends, HTTPException, BackgroundTasks
+from fastapi import (
+    FastAPI,
+    Depends,
+    HTTPException,
+    BackgroundTasks,
+    Request,
+)
+from fastapi.responses import HTMLResponse
+from fastapi.templating import Jinja2Templates
 from pydantic import BaseModel, Field
 from typing import Optional
 from redis import Redis
@@ -53,6 +61,7 @@ def setup_logging() -> None:
     )
 
 app = FastAPI(title="AI Agent Backend")
+templates = Jinja2Templates(directory="templates")
 
 async def trigger_run_agent() -> None:
     """Scheduler job that calls the /run-agent endpoint."""
@@ -122,10 +131,10 @@ app.include_router(api_router)
 app.include_router(admin_router)  # Include the new admin router
 app.include_router(config_router)
 
-# Default root path
-@app.get("/")
-async def read_root():
-    return {"message": "AI Agent Backend"}
+# Default root path serving the configuration form
+@app.get("/", response_class=HTMLResponse)
+async def read_root(request: Request):
+    return templates.TemplateResponse("config.html", {"request": request})
 
 # Health check endpoint
 @app.get("/health", status_code=200)

--- a/requirements.txt
+++ b/requirements.txt
@@ -109,6 +109,7 @@ jinja2==3.1.6
     #   instructor
     #   mkdocs
     #   mkdocs-material
+    # required for fastapi.templating.Jinja2Templates
 jiter==0.10.0
     # via
     #   instructor

--- a/templates/config.html
+++ b/templates/config.html
@@ -1,0 +1,83 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <title>Brand Configuration</title>
+</head>
+<body>
+    <h1>Brand Configuration</h1>
+    <form id="configForm" onsubmit="event.preventDefault(); saveConfig();">
+        <div>
+            <label>Display Name
+                <input type="text" id="display_name" name="display_name">
+            </label>
+        </div>
+        <div>
+            <label>Persona
+                <textarea id="persona" name="persona" rows="3"></textarea>
+            </label>
+        </div>
+        <div>
+            <label>Tone
+                <textarea id="tone" name="tone" rows="3"></textarea>
+            </label>
+        </div>
+        <div>
+            <label>Keywords (comma separated)
+                <input type="text" id="keywords" name="keywords">
+            </label>
+        </div>
+        <div>
+            <label>Banned Words (comma separated)
+                <input type="text" id="banned_words" name="banned_words">
+            </label>
+        </div>
+        <button type="submit">Save</button>
+    </form>
+    <div id="message"></div>
+
+<script>
+async function loadConfig() {
+    try {
+        const resp = await fetch('/config');
+        if (resp.ok) {
+            const data = await resp.json();
+            document.getElementById('display_name').value = data.display_name || '';
+            document.getElementById('persona').value = data.persona || '';
+            document.getElementById('tone').value = data.tone || '';
+            document.getElementById('keywords').value = (data.keywords || []).join(', ');
+            document.getElementById('banned_words').value = (data.banned_words || []).join(', ');
+        }
+    } catch (e) {
+        console.error('Failed to load configuration', e);
+    }
+}
+
+async function saveConfig() {
+    const data = {
+        display_name: document.getElementById('display_name').value,
+        persona: document.getElementById('persona').value,
+        tone: document.getElementById('tone').value,
+        keywords: document.getElementById('keywords').value.split(',').map(s => s.trim()).filter(Boolean),
+        banned_words: document.getElementById('banned_words').value.split(',').map(s => s.trim()).filter(Boolean)
+    };
+
+    const resp = await fetch('/config', {
+        method: 'POST',
+        headers: {
+            'Content-Type': 'application/json'
+        },
+        body: JSON.stringify(data)
+    });
+
+    if (resp.ok) {
+        document.getElementById('message').innerText = 'Saved!';
+    } else {
+        document.getElementById('message').innerText = 'Error saving configuration';
+    }
+}
+
+window.addEventListener('DOMContentLoaded', loadConfig);
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add Jinja2 templates comment to requirements
- create `templates/config.html` with a brand config form
- configure Jinja2Templates in the FastAPI app and render the new page at `/`

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_686fbbc2093883268d7f1423e9d6ad26