### PR TITLE
Support multiple daily email hours

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -1,5 +1,6 @@
 from functools import lru_cache
 from pydantic_settings import BaseSettings, SettingsConfigDict
+from pydantic import Field, field_validator
 from dotenv import load_dotenv
 
 load_dotenv()
@@ -23,8 +24,14 @@ class Settings(BaseSettings):
     smtp_port: int | None = None
     smtp_username: str | None = None
     smtp_password: str | None = None
-    daily_email_hour: int = 6
-    daily_email_minute: int = 0
+    daily_email_hours: list[int] = Field(default_factory=lambda: [8, 16])
+
+    @field_validator("daily_email_hours", mode="before")
+    @classmethod
+    def parse_email_hours(cls, v):  # pragma: no cover - simple parse logic
+        if isinstance(v, str):
+            return [int(h.strip()) for h in v.split(",") if h.strip()]
+        return v
     max_daily_searches: int = 90
     app_base_url: str = "http://localhost:8000"
 

--- a/app/main.py
+++ b/app/main.py
@@ -106,21 +106,22 @@ async def on_startup() -> None:
         replace_existing=True,
         misfire_grace_time=60,
     )
-    scheduler.add_job(
-        trigger_daily_email_job,
-        CronTrigger(
-            hour=settings.daily_email_hour,
-            minute=settings.daily_email_minute,
-        ),
-        id="daily_email_scheduler",
-        replace_existing=True,
-        misfire_grace_time=600,
-    )
+    for i, hour in enumerate(settings.daily_email_hours):
+        scheduler.add_job(
+            trigger_daily_email_job,
+            CronTrigger(
+                hour=hour,
+                minute=0,
+            ),
+            id=f"daily_email_scheduler_{i}",
+            replace_existing=True,
+            misfire_grace_time=600,
+        )
     scheduler.start()
     structlog.get_logger().info(
         "APScheduler started",
         interval=settings.agent_run_interval_minutes,
-        daily_email_time=f"{settings.daily_email_hour:02d}:{settings.daily_email_minute:02d}",
+        daily_email_times=",".join(str(h) for h in settings.daily_email_hours),
     )
 
 @app.on_event("shutdown")


### PR DESCRIPTION
## Summary
- allow a list of hours for scheduling summary emails
- schedule a cron job for each configured hour

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_686fdddcd39083268544da82d350d1be