### PR TITLE
Add daily summary prompt and email tools

### DIFF
--- a/app/email.py
+++ b/app/email.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+"""Send a daily summary email using SendGrid."""
+
+from sendgrid import SendGridAPIClient
+from sendgrid.helpers.mail import Mail
+
+from .config import get_settings
+from .agent import get_daily_summary
+
+
+def send_daily_email() -> None:
+    """Send the formatted daily summary via email."""
+    settings = get_settings()
+    summary = get_daily_summary()
+
+    message = Mail(
+        from_email=settings.email_sender,
+        to_emails=settings.email_recipient,
+        subject="Your Daily Digest",
+        html_content=f"<strong>Here's your daily summary:</strong><br>{summary}",
+    )
+
+    try:
+        sg = SendGridAPIClient(settings.smtp_password or "")
+        sg.send(message)
+    except Exception as exc:  # pragma: no cover - network issues
+        # Log or print is omitted to keep this helper minimal
+        pass

--- a/app/llm.py
+++ b/app/llm.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+"""Simple wrapper around the OpenAI API used for text completions."""
+
+import openai
+import structlog
+
+from .config import get_settings
+
+log = structlog.get_logger(__name__)
+settings = get_settings()
+
+if settings.openai_api_key:
+    openai.api_key = settings.openai_api_key
+else:
+    log.warning("OPENAI_API_KEY is not configured; get_completion will return empty string")
+
+
+def get_completion(prompt: str) -> str:
+    """Return the LLM completion for the given prompt.
+
+    If the OpenAI API key is missing or an error occurs, an empty string is returned.
+    """
+    if not settings.openai_api_key:
+        return ""
+
+    try:
+        resp = openai.ChatCompletion.create(
+            model="gpt-3.5-turbo",
+            messages=[{"role": "user", "content": prompt}],
+            temperature=0.2,
+        )
+        return resp.choices[0].message.content.strip()
+    except Exception as exc:  # pragma: no cover - network or API issues
+        log.error("OpenAI completion failed", error=str(exc))
+        return ""

--- a/app/prompts.py
+++ b/app/prompts.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+
+"""Prompt templates for the summarization flow."""
+
+
+def get_summarize_prompt(search_results_and_links: str) -> str:
+    """Return prompt instructing the LLM to format search results.
+
+    Each result should be summarized in one sentence with two relevant emojis
+    followed by the original link.
+    """
+    return (
+        "Please summarize the following search results. For each result, provide "
+        "a brief, one-sentence headline that captures the main point, two relevant "
+        "emojis, and the original link.\n"
+        "Format each result as follows:\n"
+        "[two relevant emojis] [one-sentence headline] [link]\n\n"
+        "Here are the search results:\n" + search_results_and_links
+    )

--- a/app/search.py
+++ b/app/search.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+"""Simple Google search helper used for the daily summary flow."""
+
+from dataclasses import dataclass
+from typing import List
+
+from googlesearch import search as google_search
+import structlog
+
+log = structlog.get_logger(__name__)
+
+
+@dataclass
+class SearchResult:
+    snippet: str
+    url: str
+
+
+def search_google(query: str = "latest news", max_results: int = 5) -> List[SearchResult]:
+    """Return a list of SearchResult from Google."""
+    results: List[SearchResult] = []
+    try:
+        raw = list(google_search(query, num_results=max_results, advanced=True))
+    except Exception as exc:  # pragma: no cover - network issues
+        log.error("Google search failed", error=str(exc))
+        return results
+
+    for r in raw:
+        url = getattr(r, "url", "") or ""
+        snippet = getattr(r, "description", "") or ""
+        if url and snippet:
+            results.append(SearchResult(snippet=snippet.strip(), url=url.strip()))
+    return results

--- a/app/storage.py
+++ b/app/storage.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+"""Utility functions to persist daily search results to a JSON file."""
+
+import json
+from dataclasses import dataclass
+from datetime import date
+from pathlib import Path
+from typing import List
+
+
+DATA_FILE = Path("search_results.json")
+
+
+@dataclass
+class StoredResult:
+    snippet: str
+    url: str
+
+
+def save_search_results(results: List[StoredResult]) -> None:
+    """Save today's search results to DATA_FILE."""
+    data = {
+        "date": date.today().isoformat(),
+        "results": [r.__dict__ for r in results],
+    }
+    try:
+        DATA_FILE.write_text(json.dumps(data), encoding="utf-8")
+    except Exception:  # pragma: no cover - write failures
+        pass
+
+
+def get_search_results_for_today() -> List[StoredResult]:
+    """Return search results saved for today, if any."""
+    if not DATA_FILE.exists():
+        return []
+    try:
+        data = json.loads(DATA_FILE.read_text(encoding="utf-8"))
+    except Exception:  # pragma: no cover - read failures
+        return []
+    if data.get("date") != date.today().isoformat():
+        return []
+    return [StoredResult(**item) for item in data.get("results", [])]


### PR DESCRIPTION
## Summary
- provide summarization prompt utility
- wrap OpenAI calls for simple completions
- add lightweight Google search helper and file-based storage
- extend agent with run_agent() and get_daily_summary()
- include SendGrid-based email sender

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_686fdf1a3bd08326ad8e16ca15639d61